### PR TITLE
moved capturing process to background thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Identical to @Andycapn/react-native-document-scanner, but with an enhancement that moves the iOS image capture process to a background thread for improved stability.
+
 ![Demo gif](https://raw.githubusercontent.com/Michaelvilleneuve/react-native-document-scanner/master/images/demo.gif)
 
 # `@Andycapn/react-native-document-scanner`

--- a/ios/IPDFCameraViewController.m
+++ b/ios/IPDFCameraViewController.m
@@ -238,14 +238,14 @@
         [self.captureSession startRunning];
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            floatdetectionRefreshRate = self->_detectionRefreshRateInMS;
-            CGFloatdetectionRefreshRateInSec = detectionRefreshRate/100;
-        
+            float detectionRefreshRate = self->_detectionRefreshRateInMS; // Korrigiert: Leerzeichen hinzugefügt
+            CGFloat detectionRefreshRateInSec = detectionRefreshRate / 100.0; // Korrigiert: Division durch 100 für Sekunden und Punkt für Fließkommadivision
+            
             if (self->_lastDetectionRate != self->_detectionRefreshRateInMS) {
-                if(self->_borderDetectTimeKeeper) {
-                    [self->_borderDetectTimeKeeperinvalidate];
+                if (self->_borderDetectTimeKeeper) {
+                    [self->_borderDetectTimeKeeper invalidate]; // Korrigiert: Leerzeichen und Schreibweise von "invalidate"
                 }
-                self->_borderDetectTimeKeeper= [NSTimerscheduledTimerWithTimeInterval:detectionRefreshRateInSec target:selfselector:@selector(enableBorderDetectFrame) userInfo:nilrepeats:YES];
+                self->_borderDetectTimeKeeper = [NSTimer scheduledTimerWithTimeInterval:detectionRefreshRateInSec target:self selector:@selector(enableBorderDetectFrame) userInfo:nil repeats:YES]; // Korrigiert: Leerzeichen und Schreibweise
             }
         
             [self hideGLKView:NO completion:nil];

--- a/ios/IPDFCameraViewController.m
+++ b/ios/IPDFCameraViewController.m
@@ -234,21 +234,25 @@
 {
     _isStopped = NO;
 
-    [self.captureSession startRunning];
-
-    float detectionRefreshRate = _detectionRefreshRateInMS;
-    CGFloat detectionRefreshRateInSec = detectionRefreshRate/100;
-
-    if (_lastDetectionRate != _detectionRefreshRateInMS) {
-        if (_borderDetectTimeKeeper) {
-            [_borderDetectTimeKeeper invalidate];
-        }
-        _borderDetectTimeKeeper = [NSTimer scheduledTimerWithTimeInterval:detectionRefreshRateInSec target:self selector:@selector(enableBorderDetectFrame) userInfo:nil repeats:YES];
-    }
-
-    [self hideGLKView:NO completion:nil];
-
-    _lastDetectionRate = _detectionRefreshRateInMS;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self.captureSession startRunning];
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            floatdetectionRefreshRate = self->_detectionRefreshRateInMS;
+            CGFloatdetectionRefreshRateInSec = detectionRefreshRate/100;
+        
+            if (self->_lastDetectionRate != self->_detectionRefreshRateInMS) {
+                if(self->_borderDetectTimeKeeper) {
+                    [self->_borderDetectTimeKeeperinvalidate];
+                }
+                self->_borderDetectTimeKeeper= [NSTimerscheduledTimerWithTimeInterval:detectionRefreshRateInSec target:selfselector:@selector(enableBorderDetectFrame) userInfo:nilrepeats:YES];
+            }
+        
+            [self hideGLKView:NO completion:nil];
+        
+            self->_lastDetectionRate = self->_detectionRefreshRateInMS;
+        });
+    });
 }
 
 - (void)stop

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@andycapn/react-native-document-scanner",
-  "version": "2.0.3",
-  "description": "Scan documents, automatic border detection, automatic crop",
+  "name": "@ertan95/react-native-document-scanner",
+  "version": "2.0.4",
+  "description": "Scan documents, automatic border detection, automatic crop. Enhanced iOS stability by moving image capture to a background thread.",
   "main": "lib/module/index.js",
   "types": "lib/typescript/index.d.ts",
   "files": [
@@ -38,14 +38,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Andycapn/react-native-document-scanner"
+    "url": "https://github.com/ertan95/react-native-document-scanner"
   },
-  "author": "Andycapn (Forked from: Woonivers (https://woonivers.com))",
+  "author": "ertan95 (Forked from: Woonivers (https://woonivers.com))",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Andycapn/react-native-document-scanner/issues"
+    "url": "https://github.com/ertan95/react-native-document-scanner/issues"
   },
-  "homepage": "https://github.com/Andycapn/react-native-document-scanner#readme",
+  "homepage": "https://github.com/ertan95/react-native-document-scanner#readme",
   "devDependencies": {
     "@babel/runtime": "^7.5.5",
     "@commitlint/config-conventional": "^8.0.0",


### PR DESCRIPTION
I moved the capturing thread to the background thread to avoid crashing. Fixes this Warning from XCode:
`Thread Performance Checker: -[AVCaptureSession startRunning] should be called from background thread. Calling it on the main thread can lead to UI unresponsiveness`